### PR TITLE
Add start script and update docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "start": "npm run dev",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/readme.md
+++ b/readme.md
@@ -106,10 +106,10 @@ Header and Footer fetch from `/common/header.json` and `/common/footer.json`.
    npm install
    ```
 
-3. Run the app:
+3. Run the app (development mode):
 
    ```bash
-   npm run dev
+   npm start
    ```
 
 4. Add your page content inside `content.json` for each page.


### PR DESCRIPTION
## Summary
- add `start` script aliasing `npm run dev`
- document updated `npm start` usage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535d7aa310833288392570cd8d0554