### PR TITLE
Add sass compiler dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "sass-embedded": "^1.65.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `sass-embedded` as a dev dependency to allow compiling SCSS files

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68535fe4fc648332876b41c57820df06