### PR TITLE
Center layout and add main padding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,15 +12,17 @@ import './App.scss';
 export default function App() {
   return (
     <Router>
-      <Header />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/account/login" element={<Login />} />
-        <Route path="/account/register" element={<Register />} />
-        <Route path="/account/forgot" element={<ForgotPassword />} />
-      </Routes>
-      <Footer />
+      <div className="container mx-auto">
+        <Header />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/account/login" element={<Login />} />
+          <Route path="/account/register" element={<Register />} />
+          <Route path="/account/forgot" element={<ForgotPassword />} />
+        </Routes>
+        <Footer />
+      </div>
     </Router>
   );
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,3 +1,3 @@
 main {
-  padding: 1rem;
+  padding: 0;
 }

--- a/src/pages/About/About.jsx
+++ b/src/pages/About/About.jsx
@@ -3,7 +3,7 @@ import content from './content.json';
 
 export default function About() {
   return (
-    <main>
+    <main className="p-[30px]">
       <h2>{content.title}</h2>
       <p>{content.description}</p>
     </main>

--- a/src/pages/Account/ForgotPassword.jsx
+++ b/src/pages/Account/ForgotPassword.jsx
@@ -4,7 +4,7 @@ import content from './content.json';
 export default function ForgotPassword() {
   const data = content.forgot;
   return (
-    <main>
+    <main className="p-[30px]">
       <h2>{data.title}</h2>
       <button>{data.button}</button>
     </main>

--- a/src/pages/Account/Login.jsx
+++ b/src/pages/Account/Login.jsx
@@ -4,7 +4,7 @@ import content from './content.json';
 export default function Login() {
   const data = content.login;
   return (
-    <main>
+    <main className="p-[30px]">
       <h2>{data.title}</h2>
       <button>{data.button}</button>
     </main>

--- a/src/pages/Account/Register.jsx
+++ b/src/pages/Account/Register.jsx
@@ -4,7 +4,7 @@ import content from './content.json';
 export default function Register() {
   const data = content.register;
   return (
-    <main>
+    <main className="p-[30px]">
       <h2>{data.title}</h2>
       <button>{data.button}</button>
     </main>

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -3,7 +3,7 @@ import content from './content.json';
 
 export default function Home() {
   return (
-    <main>
+    <main className="p-[30px]">
       <h2>{content.title}</h2>
       <p>{content.description}</p>
     </main>


### PR DESCRIPTION
## Summary
- wrap main layout in a centered Tailwind container
- move default padding for `<main>` into Tailwind classes on pages
- reset the old SCSS padding rule

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685367f45cb08332af47ea9682350867